### PR TITLE
Fix single input AND gates

### DIFF
--- a/datagen/utilities/andAIG2Graphml.py
+++ b/datagen/utilities/andAIG2Graphml.py
@@ -78,7 +78,7 @@ def parseAIGBenchAndCreateNetworkXGraph():
     benchFile = open(INPUT_BENCH,'r+')
     benchFileLines = benchFile.readlines()
     benchFile.close()
-    AIG_DAG = nx.DiGraph()
+    AIG_DAG = nx.MultiDiGraph()
     idxCounter = 0
     for line in benchFileLines:
         if len(line) == 0 or line.__contains__("ABC"):


### PR DESCRIPTION
Hello! There is a problem of single input internal nodes in GraphML-files. For example in k2_orig:
BENCH (It is const 0 in AIG):
```
INPUT(pp)
...
pp_inv = NOT(pp)
...
new_n91_ = AND(pp,pp_inv)

```
But, after using andAIG2Graphml.py we get only one inverted edge:
```
    <node id="0">
      <data key="d0">pp</data>
      <data key="d1">0</data>
      <data key="d2">0</data>
    </node>
...
    <node id="45">
      <data key="d0">new_n91_</data>
      <data key="d1">2</data>
      <data key="d2">1</data>
    </node>
...
    <edge source="45" target="0">
      <data key="d3">1</data>
    </edge>

```
It should be:
```
    <node id="0">
      <data key="d0">pp</data>
      <data key="d1">0</data>
      <data key="d2">0</data>
    </node>
...
    <node id="45">
      <data key="d0">new_n91_</data>
      <data key="d1">2</data>
      <data key="d2">1</data>
    </node>
...
    <edge source="45" target="0">
      <data key="d3">0</data>
    </edge>
    <edge source="45" target="0">
      <data key="d3">1</data>
    </edge>
```
So, I suggest we use nx.MultiDiGraph in andAIG2Graphml.py to get two edges:
```
    <edge source="45" target="0" id="0">
      <data key="d3">0</data>
    </edge>
    <edge source="45" target="0" id="1">
      <data key="d3">1</data>
    </edge>
```
But, it will lead to appearance of edges idxs.